### PR TITLE
feat: Gemma 3 local LLM integration via Ollama (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 ### Backend
 - **Flask** – API framework
 - **Python 3.8+** – Core programming language
-- **Google Gemini API (gemini-2.5-flash)** – LLM for orchestration
+- **Gemma 3 (4B) via Ollama** – default local LLM backend (privacy-first, offline)
+- **Google Gemini API** – optional cloud backend (`LLM_BACKEND=gemini`)
 - **Pandas** – Data processing
 - **SQLite3** – Handles database files
 
@@ -43,7 +44,16 @@ bash
     pip install -r requirements.txt
 4. **Configure environment variables** Create a .env file in the root directory:
 env
-   GOOGLE_API_KEY=your_gemini_api_key_here
+   # Local Gemma 3 (default)
+   LLM_BACKEND=ollama
+   OLLAMA_URL=http://localhost:11434
+   OLLAMA_MODEL=gemma3:4b
+
+   # Optional: cloud Gemini fallback
+   # LLM_BACKEND=gemini
+   # GOOGLE_API_KEY=your_gemini_api_key_here
+
+   Pull the model once: `ollama pull gemma3:4b`
 5. **Run the application**
 bash
    python app.py

--- a/app.py
+++ b/app.py
@@ -1,24 +1,18 @@
-# ...existing code...
 from flask import Flask, render_template, request, jsonify, Response
 import os
 import uuid
+
 from tools.llm.llm_client import get_llm_client
 from tools.data_ingestion.parser import handle_file_upload
-from tools.context_management.context_handler import read_context, write_context, update_context_from_llm
+from tools.context_management.context_handler import read_context, write_context
 from tools.llm.orchestrator import process_user_message, cotas_generate_insights
 
-# instantiate central LLM client (configured via env: LLM_BACKEND, OLLAMA_URL, OLLAMA_MODEL)
 _llm_client = get_llm_client()
 
 app = Flask(__name__)
-app.config["MAX_CONTENT_LENGTH"] = 100 * 1024 * 1024  # 100MB max file size
+app.config["MAX_CONTENT_LENGTH"] = 100 * 1024 * 1024
 
 BASE_STORAGE = "storage"
-
-
-def _call_llm(prompt: str, max_tokens: int = 512, temperature: float = 0.0, stream: bool = False):
-
-    return _llm_client.generate(prompt=prompt, max_tokens=max_tokens, temperature=temperature, stream=stream)
 
 
 def get_session_path(session_id: str) -> dict:
@@ -123,7 +117,7 @@ def generate_insights():
             for update in cotas_generate_insights(paths, user_goal, max_loops):
                 yield f"data: {update}\n\n"
         except Exception as e:
-            yield f"data: {{\"error\": \"Analysis failed: {str(e)}\"}}\n\n"
+            yield f'data: {{"error": "Analysis failed: {str(e)}"}}\n\n'
 
     return Response(generate(), mimetype="text/event-stream")
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,56 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.llm.llm_client import (
+    DEFAULT_OLLAMA_MODEL,
+    GeminiClient,
+    OllamaClient,
+    get_llm_client,
+    strip_json_fences,
+)
+
+
+class TestStripJsonFences(unittest.TestCase):
+    def test_plain_json(self):
+        self.assertEqual(strip_json_fences('{"a": 1}'), '{"a": 1}')
+
+    def test_fenced_json(self):
+        raw = '```json\n{"a": 1}\n```'
+        self.assertEqual(strip_json_fences(raw), '{"a": 1}')
+
+
+class TestOllamaClient(unittest.TestCase):
+    @patch("tools.llm.llm_client.requests.post")
+    def test_generate_parses_response_field(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"response": "hello from gemma"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient(model="gemma3:4b", base_url="http://localhost:11434")
+        self.assertEqual(client.generate("test prompt"), "hello from gemma")
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["model"], "gemma3:4b")
+        self.assertFalse(payload["stream"])
+
+
+class TestGetLlmClient(unittest.TestCase):
+    @patch.dict(os.environ, {"LLM_BACKEND": "ollama", "OLLAMA_MODEL": "gemma3:4b"}, clear=False)
+    def test_defaults_to_ollama(self):
+        client = get_llm_client()
+        self.assertIsInstance(client, OllamaClient)
+        self.assertEqual(client.model, DEFAULT_OLLAMA_MODEL)
+
+    @patch.dict(os.environ, {"LLM_BACKEND": "gemini"}, clear=False)
+    @patch("tools.llm.llm_client.GeminiClient")
+    def test_gemini_backend(self, mock_gemini_cls):
+        sentinel = object()
+        mock_gemini_cls.return_value = sentinel
+        client = get_llm_client()
+        self.assertIs(client, sentinel)
+        mock_gemini_cls.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/data_ingestion/parser.py
+++ b/tools/data_ingestion/parser.py
@@ -4,18 +4,12 @@ import json
 import time
 import sqlite3
 from typing import Dict, Any
-from dotenv import load_dotenv
-import google.generativeai as genai
 
 from tools.context_management.context_handler import append_dataset_metadata, update_context_from_llm
-
-load_dotenv()
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
+from tools.llm.llm_client import generate_text, strip_json_fences
 
 
 def extract_metadata_with_llm(filename: str, basic_metadata: Dict[str, Any]) -> Dict[str, Any]:
-    model = genai.GenerativeModel("gemini-1.5-flash")
-
     prompt = f"""Analyze this dataset metadata and provide rich context:
 
 FILENAME: {filename}
@@ -34,14 +28,7 @@ Respond with ONLY a JSON object containing:
 Only valid JSON, no additional text."""
 
     try:
-        response = model.generate_content(prompt)
-        response_text = getattr(response, "text", "{}").strip()
-
-        if "```json" in response_text:
-            response_text = response_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in response_text:
-            response_text = response_text.split("```")[1].split("```")[0].strip()
-
+        response_text = strip_json_fences(generate_text(prompt, max_tokens=1024))
         return json.loads(response_text)
     except Exception as e:
         return {

--- a/tools/llm/llm_client.py
+++ b/tools/llm/llm_client.py
@@ -1,0 +1,133 @@
+"""Unified LLM client supporting local Gemma 3 via Ollama or cloud Gemini."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterator, Union
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+DEFAULT_OLLAMA_MODEL = "gemma3:4b"
+DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+
+
+def strip_json_fences(text: str) -> str:
+    cleaned = text.strip()
+    if "```json" in cleaned:
+        cleaned = cleaned.split("```json", 1)[1].split("```", 1)[0].strip()
+    elif "```" in cleaned:
+        cleaned = cleaned.split("```", 1)[1].split("```", 1)[0].strip()
+    return cleaned
+
+
+class OllamaClient:
+    """Local inference via Ollama (Gemma 3 4B recommended)."""
+
+    def __init__(
+        self,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout: int = 120,
+    ):
+        self.model = model or os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
+        self.base_url = (base_url or os.getenv("OLLAMA_URL", "http://localhost:11434")).rstrip("/")
+        self.timeout = int(os.getenv("OLLAMA_TIMEOUT", timeout))
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 512,
+        temperature: float = 0.0,
+        stream: bool = False,
+    ) -> Union[str, Iterator[str]]:
+        url = f"{self.base_url}/api/generate"
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": stream,
+            "options": {"num_predict": max_tokens, "temperature": temperature},
+        }
+
+        if stream:
+            return self._stream(url, payload)
+        resp = requests.post(url, json=payload, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict):
+            return data.get("response") or json.dumps(data)
+        return str(data)
+
+    def _stream(self, url: str, payload: dict) -> Iterator[str]:
+        with requests.post(url, json=payload, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            for line in resp.iter_lines(decode_unicode=True):
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    chunk = data.get("response", "")
+                    if chunk:
+                        yield chunk
+                except json.JSONDecodeError:
+                    yield line
+
+
+class GeminiClient:
+    """Cloud Gemini fallback when LLM_BACKEND=gemini."""
+
+    def __init__(self, model: str | None = None):
+        import google.generativeai as genai
+
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            raise ValueError("GOOGLE_API_KEY required when LLM_BACKEND=gemini")
+        genai.configure(api_key=api_key)
+        self._genai = genai
+        self.model_name = model or os.getenv("GEMINI_MODEL", DEFAULT_GEMINI_MODEL)
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 512,
+        temperature: float = 0.0,
+        stream: bool = False,
+    ) -> Union[str, Iterator[str]]:
+        if stream:
+            raise NotImplementedError("Gemini streaming not implemented in this client")
+        model = self._genai.GenerativeModel(self.model_name)
+        response = model.generate_content(
+            prompt,
+            generation_config={"max_output_tokens": max_tokens, "temperature": temperature},
+        )
+        return getattr(response, "text", str(response)).strip()
+
+
+def get_llm_client(model: str | None = None) -> OllamaClient | GeminiClient:
+    backend = os.getenv("LLM_BACKEND", "ollama").lower()
+    if backend == "gemini":
+        return GeminiClient(model)
+    return OllamaClient(model=model)
+
+
+def generate_text(
+    prompt: str,
+    max_tokens: int = 2048,
+    temperature: float = 0.0,
+    model: str | None = None,
+) -> str:
+    client = get_llm_client(model)
+    result = client.generate(
+        prompt=prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        stream=False,
+    )
+    return str(result).strip()

--- a/tools/llm/orchestrator.py
+++ b/tools/llm/orchestrator.py
@@ -2,18 +2,13 @@ import json
 import os
 import time
 from typing import Dict, Any, Generator
-from dotenv import load_dotenv
-import google.generativeai as genai
 
 from tools.context_management.context_handler import (
     read_context, write_context, append_to_chat_history, 
     update_context_from_llm
 )
 from tools.script_executor.sandbox import run_script_safely
-
-load_dotenv()
-api_key = os.getenv("GOOGLE_API_KEY")
-genai.configure(api_key=api_key)
+from tools.llm.llm_client import generate_text, strip_json_fences
 
 def process_user_message(message: str, paths: dict) -> dict:
     context = read_context(paths["context"])
@@ -48,17 +43,8 @@ Example output:
 
 Respond with ONLY valid JSON, no additional text."""
 
-    model = genai.GenerativeModel("gemini-2.5-flash")
-    
     try:
-        response = model.generate_content(prompt)
-        response_text = getattr(response, "text", str(response)).strip()
-        
-        if "```json" in response_text:
-            response_text = response_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in response_text:
-            response_text = response_text.split("```")[1].split("```")[0].strip()
-        
+        response_text = strip_json_fences(generate_text(prompt))
         result = json.loads(response_text)
         
         if result.get("context_update"):
@@ -104,7 +90,6 @@ Respond with ONLY valid JSON, no additional text."""
 def cotas_generate_insights(paths: dict, user_goal: str, max_loops: int = 15) -> Generator[str, None, None]:
     context = read_context(paths["context"])
     dataset_metadata = read_context(paths["dataset_metadata"])
-    model = genai.GenerativeModel("gemini-2.5-flash")
     
     cotas_log = {"goal": user_goal, "steps": [], "start_time": int(time.time())}
     
@@ -173,14 +158,7 @@ OR
 No additional text. Only valid JSON."""
 
         try:
-            response = model.generate_content(decision_prompt)
-            response_text = getattr(response, "text", str(response)).strip()
-            
-            if "```json" in response_text:
-                response_text = response_text.split("```json")[1].split("```")[0].strip()
-            elif "```" in response_text:
-                response_text = response_text.split("```")[1].split("```")[0].strip()
-            
+            response_text = strip_json_fences(generate_text(decision_prompt))
             decision = json.loads(response_text)
             
             if "action" not in decision or "content" not in decision:
@@ -304,9 +282,8 @@ Provide a brief insight about:
 Respond with only the insight text, no formatting."""
 
             try:
-                insight_resp = model.generate_content(insight_prompt)
-                insight = getattr(insight_resp, "text", stdout or stderr).strip()
-            except:
+                insight = generate_text(insight_prompt, max_tokens=512).strip()
+            except Exception:
                 insight = stdout or stderr or "Execution completed"
             
             last_output = insight


### PR DESCRIPTION
## Migrate from Gemini to Gemma 3 (4B) — local inference

Integrates the local LLM layer into the main codebase per issue #4 (commits on **`local-model`** branch).

### Changes

1. **`tools/llm/llm_client.py`** — unified client with `OllamaClient` (default, Gemma 3 4B) and optional `GeminiClient` fallback via `LLM_BACKEND=gemini`.
2. **`orchestrator.py` / `parser.py`** — all Gemini direct calls replaced with `generate_text()` so CoTAS and upload metadata work offline.
3. **`app.py`** — uses shared `get_llm_client()` (removed inline duplicate Ollama class).
4. **README** — documents Ollama setup (`ollama pull gemma3:4b`).
5. **Tests** — `tests/test_llm_client.py` covers JSON fence stripping, Ollama response parsing, backend selection.

### Env vars

```env
LLM_BACKEND=ollama          # default
OLLAMA_URL=http://localhost:11434
OLLAMA_MODEL=gemma3:4b
# LLM_BACKEND=gemini + GOOGLE_API_KEY for cloud fallback
```

### Testing

```bash
python -m unittest discover -s tests -v
```

Closes #4


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`